### PR TITLE
reactify not needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,7 @@
     "vinyl-source-stream": "^1.0.0",
     "watchify": "^2.1.1"
   },
-  "browserify": {
-    "transform": [
-      "reactify"
-    ]
-  },
+  "browserify": {},
   "browserify-shim": {
     "react": "global:React"
   },


### PR DESCRIPTION
The Tappable.js file doesn't have any JSX in it. So the Reactify tranform isn't required with browserify.