### PR TITLE
Fix bug by adding missing argument

### DIFF
--- a/src/Tappable.js
+++ b/src/Tappable.js
@@ -169,7 +169,7 @@ function extend(target, source) {
 		this.endTouch(event);
 	},
 	
-	endTouch: function() {
+	endTouch: function(event) {
 		this.cancelPressDetection();
 		this.props.onTouchEnd && this.props.onTouchEnd(event);
 		this._initialTouch = null;


### PR DESCRIPTION
The endTouch method was missing the event argument which is then used in the function.
Fixed a bug that cause a javascript error when supplied with an onTouchEnd handler.