### PR TITLE
make props more flexible

### DIFF
--- a/src/Tappable.js
+++ b/src/Tappable.js
@@ -383,23 +383,24 @@ var component = React.createClass({
 		var style = {};
 		extend(style, this.touchStyles(), props.style);
 
-		var newComponentProps = {
+		var newComponentProps = extend({}, props, {
 			style: style,
 			className: className,
 			disabled: props.disabled,
-			onTouchStart: this.onTouchStart,
-			onTouchMove: this.onTouchMove,
-			onTouchEnd: this.onTouchEnd,
-			onMouseDown: this.onMouseDown,
-			onMouseMove: this.onMouseMove,
-			onMouseUp: this.onMouseUp,
-			onMouseOut: this.onMouseOut
-		};
+			handlers: this.handlers
+		}, this.handlers());
 
-		var dataOrAriaPropNames = Object.keys(props).filter(isDataOrAriaProp);
-		dataOrAriaPropNames.forEach(function (propName) {
-			newComponentProps[propName] = props[propName];
-		});
+		delete newComponentProps.onTap;
+		delete newComponentProps.onPress;
+		delete newComponentProps.onPinchStart;
+		delete newComponentProps.onPinchMove;
+		delete newComponentProps.onPinchEnd;
+		delete newComponentProps.moveThreshold;
+		delete newComponentProps.pressDelay;
+		delete newComponentProps.pressMoveThreshold;
+		delete newComponentProps.preventDefault;
+		delete newComponentProps.stopPropagation;
+		delete newComponentProps.component;
 
 		return React.createElement(props.component, newComponentProps, props.children);
 	}


### PR DESCRIPTION
This pull request changes the props that are sent to the child component. Instead of only passing down `data-` and `aria-` props down, it now passes down ALL props that are not specifically for React-Tappable itself.

The main reason to do this is to make it possible to use custom components with React-Tappable. Currently, similar functionality is possible by using the React-Tappable Mixin, but mixins are not likely to work with ES6 classes in the near future.

This solution makes it possible to use React-Tappble itself, when you would earlier use a mixin.


Example usage:

```
class CustomComponent extends React.component {
  render(){
    return (
      <div {...this.props.handlers}>
        {everythingElse}
      </div>
    )
  }
}
```
(Compared to using mixins, `this.handlers` is replaced with `this.props.handlers`)
Now this custom component can be used elsewhere with React-Tappable like this:

```
import Tappable from 'react-tappable'
import CustomComponent from './CustomComponent'
<Tappable component={CustomComponent} onTap={this.onTap} customProp='x' customProp2='y' />
```

This allows you to easily add Tappable powers to any component easily, and without mixins.

Additionally, for simple string based components, (like span, div etc.) The extra props are just ignored by React and are hence harmless.