### PR TITLE
Added touch identifier checking to pinchMove

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ Pinch events come with a special object with additional data to actually be more
 
 #### Known Issues
 
-* The touches array isn't ordered according to the initial pinch event's identifiers. Rare cases, where the touch order changes, can result in surprising behaviour
 * The pinch implementation has not been thoroughly tested
 * Any touch event with 3 three or more touches is completely ignored.
 

--- a/src/Tappable.js
+++ b/src/Tappable.js
@@ -128,7 +128,18 @@ var Mixin = {
 		if (this._initialTouch) this.endTouch();
 
 		var touches = event.touches;
-		var currentPinch = getPinchProps(touches); //TODO add helper function to order touches by identifier
+
+		if(touches.length !== 2){
+			return this.onPinchEnd(event) // bail out before disaster
+		}
+
+		var currentPinch =
+			touches[0].identifier === this._initialPinch.touches[0].identifier && touches[1].identifier === this._initialPinch.touches[1].identifier ?
+				getPinchProps(touches) // the touches are in the correct order
+			: touches[1].identifier === this._initialPinch.touches[0].identifier && touches[0].identifier === this._initialPinch.touches[1].identifier ?
+				getPinchProps(touches.reverse()) // the touches have somehow changed order
+			:
+				getPinchProps(touches); // something is wrong, but we still have two touch-points, so we try not to fail
 
 		currentPinch.displacement = {
 			x: currentPinch.center.x - this._initialPinch.center.x,
@@ -170,9 +181,11 @@ var Mixin = {
 		this._initialPinch = this._lastPinch = null;
 
 		// If one finger is still on screen, it should start a new touch event for swiping etc
-		if (event.touches.length === 1) {
-			this.onTouchStart(event);
-		}
+		// But it should never fire an onTap or onPress event.
+		// Since there is no support swipes yet, this should be disregarded for now
+		// if (event.touches.length === 1) {
+		// 	this.onTouchStart(event);
+		// }
 	},
 
 	initScrollDetection: function() {


### PR DESCRIPTION
Also, I commented out the code that fire `touchStart` when one finger was lifted during a pinch event.
After a pinch event, only swipes should be detected. onTap and onPress should never fire if there was (were?) more than one finger on the screen.

Also, removed the line from Readme that talked about the identifier problem.