### PR TITLE
Remove useless line (i think)

### DIFF
--- a/src/getComponent.js
+++ b/src/getComponent.js
@@ -40,8 +40,7 @@ module.exports = function (mixins) {
 			var newComponentProps = Object.assign({}, props, {
 				style: style,
 				className: className,
-				disabled: props.disabled,
-				handlers: this.handlers
+				disabled: props.disabled
 			}, this.handlers());
 
 			delete newComponentProps.onTap;


### PR DESCRIPTION
```
            var newComponentProps = Object.assign({}, props, {
                style: style,
                className: className,
                disabled: props.disabled,
                handlers: this.handlers
            }, this.handlers());
```

I'm not sure but  it seems to me this line `handlers: this.handlers` is useless right?
