### PR TITLE
`detectScroll()` didn't work properly on Android

### DIFF
--- a/src/TappableMixin.js
+++ b/src/TappableMixin.js
@@ -66,6 +66,7 @@ var Mixin = {
 			this._initialTouch = this._lastTouch = getTouchProps(event.touches[0]);
 			this.initScrollDetection();
 			this.initPressDetection(event, this.endTouch);
+			this.initTouchmoveDetection();
 			this._activeTimeout = setTimeout(this.makeActive, this.props.activeDelay);
 		} else if (this.onPinchStart &&
 				(this.props.onPinchStart || this.props.onPinchMove || this.props.onPinchEnd) &&
@@ -100,6 +101,18 @@ var Mixin = {
 				this._scrollPos.left += node.scrollLeft;
 			}
 			node = node.parentNode;
+		}
+	},
+
+	initTouchmoveDetection: function () {
+		this._touchmoveTriggeredTimes = 0;
+	},
+
+	cancelTouchmoveDetection: function () {
+		if (this._touchmoveDetectionTimeout) {
+			clearTimeout(this._touchmoveDetectionTimeout);
+			this._touchmoveDetectionTimeout = null;
+			this._touchmoveTriggeredTimes = 0;
 		}
 	},
 
@@ -140,7 +153,17 @@ var Mixin = {
 		if (this._initialTouch) {
 			this.processEvent(event);
 
-			if (this.detectScroll()) return this.endTouch(event);
+			if (this.detectScroll()) {
+				return this.endTouch(event);
+			} else {
+				if ((this._touchmoveTriggeredTimes)++ === 0) {
+					this._touchmoveDetectionTimeout = setTimeout(function() {
+						if (this._touchmoveTriggeredTimes === 1) {
+							this.endTouch(event);
+						}
+					}.bind(this), 64);
+				}
+			}
 
 			this.props.onTouchMove && this.props.onTouchMove(event);
 			this._lastTouch = getTouchProps(event.touches[0]);
@@ -194,6 +217,7 @@ var Mixin = {
 	},
 
 	endTouch: function (event, callback) {
+		this.cancelTouchmoveDetection();
 		this.cancelPressDetection();
 		this.clearActiveTimeout();
 		if (event && this.props.onTouchEnd) {


### PR DESCRIPTION
# `detectScroll()` didn't work properly on Android

I had been working on a Hybrid Mobile App recently. `react-tappable` was powerful and easy-to-use, saving us lots of time from re-inventing the wheel... Thanks for your outstanding work! :D

It worked pretty well both on Chrome for OS X and Safari for iOS. However, in the last days before releasing our app, we found a fetal bug when testing on Android. Links of video re-producing the bug follow:

- [Re-producing touch events bug of react-tappable on Android (Simulator)](https://vimeo.com/137674507)
- [Attempting to re-produce the same bug on iPhone](https://vimeo.com/137671754)

As demonstrated in the videos, the bug is Android-only. Every time I tried scrolling the `Tappable` element, it turns to `.Tappable-active` status and won't go back. It stays blue until another tap.

After hours of googling, I finally figured out that it's due to the lack of triggering of `touchend`, when scrolling is not stopped by `preventDefault()` in `touchstart` or the first `touchmove`. Please check out [this article](http://blog.mobiscroll.com/working-with-touch-events/) for detailed explanation. It's [a long-existed bug](http://stackoverflow.com/questions/2987706/touchend-event-doesnt-work-on-android) since Android 4.0 (or 2.3, maybe).

Having some hacking on the code, I found that `detectScroll()` couldn't work properly when user scrolling the `Tappable` element, since `touchmove` only triggered once somehow (twice in some rare cases). But `detectScroll()` needs at least two triggerings of `touchmove` to diff out the change of scrolling positions! I did some further tests. These screenshots show why `detectScroll()` returns `false` all the time on Android.

**Android:** http://i.imgur.com/cq357Cq.png
**iOS:** http://i.imgur.com/N74jgei.png
**Chrome (OS X):** http://i.imgur.com/XLlUIni.png

So we have to work around the bug. Since it only triggered once on Android and multiple times on iOS frequently & quickly, we could count the times of `touchmove` after the first triggering. If another triggering not occured in a very short time (I have set it to 64ms, period of ~4 frames in 60fps), we assume  something is buggy and `touchend` should be triggered manually.

The final result seems fine for me. The demo videos follow:

- [Demo: Patched react-tappable on Android](https://vimeo.com/137674852)
- [Demo: Patched react-tappable on iPhone](https://vimeo.com/137674853)

The codes for demo are placed in:

- https://github.com/riophae/react-tappable/tree/bug-reproducing
- https://github.com/riophae/react-tappable/tree/demo
