### PR TITLE
Support for active and inactive classes

### DIFF
--- a/lib/getComponent.js
+++ b/lib/getComponent.js
@@ -19,6 +19,7 @@ module.exports = function (mixins) {
 			component: React.PropTypes.any, // component to create
 			className: React.PropTypes.string, // optional className
 			classBase: React.PropTypes.string, // base for generated classNames
+			classes: React.PropTypes.object, // object containing the active and inactive class names
 			style: React.PropTypes.object, // additional style properties for the component
 			disabled: React.PropTypes.bool // only applies to buttons
 		},
@@ -36,6 +37,10 @@ module.exports = function (mixins) {
 
 			if (props.className) {
 				className += ' ' + props.className;
+			}
+
+			if (props.classes) {
+				className += ' ' + (this.state.isActive ? props.classes.active : props.classes.inactive);
 			}
 
 			var style = {};

--- a/src/getComponent.js
+++ b/src/getComponent.js
@@ -15,6 +15,7 @@ module.exports = function (mixins) {
 			component: React.PropTypes.any,           // component to create
 			className: React.PropTypes.string,        // optional className
 			classBase: React.PropTypes.string,        // base for generated classNames
+			classes: React.PropTypes.object,          // object containing the active and inactive class names
 			style: React.PropTypes.object,            // additional style properties for the component
 			disabled: React.PropTypes.bool            // only applies to buttons
 		},
@@ -32,6 +33,10 @@ module.exports = function (mixins) {
 
 			if (props.className) {
 				className += ' ' + props.className;
+			}
+
+			if (props.classes) {
+				className += ' ' + (this.state.isActive ? props.classes.active : props.classes.inactive);
 			}
 
 			var style = {};


### PR DESCRIPTION
Support for active and inactive classes, kinda like Custom Classes for ReactCSSTransitionGroup in React v0.14.

```
<Tappable classes={{active: css.itemactive, inactive: css.item}} ......
```

A necessity when using 'css modules' where every classname becomes unique.
https://github.com/css-modules/css-modules