### PR TITLE
Bypass setTimeout when activation should happen immediately

### DIFF
--- a/src/TappableMixin.js
+++ b/src/TappableMixin.js
@@ -73,7 +73,11 @@ var Mixin = {
 			this.initScrollDetection();
 			this.initPressDetection(event, this.endTouch);
 			this.initTouchmoveDetection();
-			this._activeTimeout = setTimeout(this.makeActive, this.props.activeDelay);
+			if (this.props.activeDelay > 0) {
+				this._activeTimeout = setTimeout(this.makeActive, this.props.activeDelay);
+			} else {
+				this.makeActive();
+			}
 		} else if (this.onPinchStart &&
 				(this.props.onPinchStart || this.props.onPinchMove || this.props.onPinchEnd) &&
 				event.touches.length === 2) {


### PR DESCRIPTION
This should fix #73 because even with a zero timeout, setTimeout does not execute immediately.  Without this change, setting activeDelay to zero (which is the default) still results in about a quarter second or so delay on my phone.  The delay seems shorter on my desktop, but is still noticable.