### PR TITLE
Fix nulled event in onPress callback.

### DIFF
--- a/lib/TappableMixin.js
+++ b/lib/TappableMixin.js
@@ -71,6 +71,8 @@ var Mixin = {
 		this.processEvent(event);
 		window._blockMouseEvents = true;
 		if (event.touches.length === 1) {
+			// SyntheticEvent objects are pooled, so persist the event so it can be referenced asynchronously
+			event.persist();
 			this._initialTouch = this._lastTouch = getTouchProps(event.touches[0]);
 			this.initScrollDetection();
 			this.initPressDetection(event, this.endTouch);

--- a/src/TappableMixin.js
+++ b/src/TappableMixin.js
@@ -69,6 +69,8 @@ var Mixin = {
 		this.processEvent(event);
 		window._blockMouseEvents = true;
 		if (event.touches.length === 1) {
+			// SyntheticEvent objects are pooled, so persist the event so it can be referenced asynchronously
+			event.persist();
 			this._initialTouch = this._lastTouch = getTouchProps(event.touches[0]);
 			this.initScrollDetection();
 			this.initPressDetection(event, this.endTouch);


### PR DESCRIPTION
The SyntheticEvent is pooled (https://facebook.github.io/react/docs/events.html#event-pooling) for performance reasons, which means the event object cannot be normally accessed asynchronously. Persisting the event object fixes the issue.

Fixes #62 