### PR TITLE
Bump dependencies to comply with react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "peerDependencies": {
     "create-react-class": "^15.5.2",
     "prop-types": "^15.5.8",
-    "react": "^0.14 || ^15.0.0-rc || ^15.0.0",
-    "react-dom": "^0.14 || ^15.0.0-rc || ^15.0.0"
+    "react": "^0.14 || ^15.0.0-rc || ^15.0.0 || ^16.0.0",
+    "react-dom": "^0.14 || ^15.0.0-rc || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.3",
@@ -22,9 +22,9 @@
     "eslint-plugin-react": "^3.5.1",
     "gulp": "^3.9.1",
     "prop-types": "^15.5.8",
-    "react": "^0.14 || ^15.0.0-rc || ^15.0.0",
+    "react": "^0.14 || ^15.0.0-rc || ^15.0.0 || ^16.0.0",
     "react-component-gulp-tasks": "^0.7.7",
-    "react-dom": "^0.14 || ^15.0.0-rc || ^15.0.0"
+    "react-dom": "^0.14 || ^15.0.0-rc || ^15.0.0 || ^16.0.0"
   },
   "browserify-shim": {
     "create-react-class": "global:createReactClass",


### PR DESCRIPTION
I am currently getting a peer dependency warning which will be resolved after this merge.